### PR TITLE
Add demo of non-nanosecond timesteps in pandas

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,4 @@ jobs:
 
       - name: Run selected notebooks
         run: | 
-          pytest --nbmake --nbmake-kernel=paleopandas examples/Playing_with_Series_in_Pyleoclim.ipynb
+          pytest --nbmake --nbmake-kernel=paleopandas examples/Playing_with_Series_in_Pyleoclim.ipynb examples/Non-nanosecond_Series.ipynb

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd paleoPandas
 ```
 
 Now you'll build a conda environment to ensure that all the required packages
-are installed. 
+are installed. NOTE: You may want to use `mamba` for a quicker solve (same results).
 
 ```
 conda env create -f environment.yml

--- a/examples/Non-nanosecond_Series.ipynb
+++ b/examples/Non-nanosecond_Series.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f65efa55-efe1-4980-95d6-ee5d12867ce3",
+   "metadata": {},
+   "source": [
+    "# Demonstration of current state of non-nanosecond time in Pandas \n",
+    "(as of 2.0.0.dev0+664.g86f182829d)  \n",
+    "We still need to use numpy to get to the previously out of bounds dates.   \n",
+    "This will be resolved once the `to_datetime` functionality is updated (estimated prior to 2.0)  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4783f1b4-7692-4eae-9b42-590d95d21c3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87ac17c1-8647-4191-9ded-a39e944eed66",
+   "metadata": {},
+   "source": [
+    "### **[New Feature]** Dates far in the past"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "643da6b6-4d08-4e84-a1c1-c23088384c54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.Series(['1700-01-01'], dtype='datetime64[s]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35bd9efa-72a1-447d-bedd-5a00300eff79",
+   "metadata": {},
+   "source": [
+    "### **[New Feature]** Dates far into the future represented as a Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e987617-2271-4124-a65a-7bca07e060e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr2 = np.array([\"30456-01-02\"], dtype=\"M8[s]\")\n",
+    "\n",
+    "# as series\n",
+    "pd.Series(arr2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb020251-8170-4aee-a61e-d3644c1a3162",
+   "metadata": {},
+   "source": [
+    "### **[New Feature]** Dates far into the future represented as an Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0161afec-5ae8-4205-ba8f-b0c3a61f0a1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# or as a index\n",
+    "pd.Index(arr2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "648f5dd6-1e7c-4ead-ae49-c4b8681f2800",
+   "metadata": {},
+   "source": [
+    "### **[New Feature]** Long spanning time series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a762a535-8572-4172-9d6a-983c4ba6e061",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr = np.arange(1000, dtype=np.int64).view(\"M8[100Y]\").astype(\"M8[s]\")\n",
+    "pd.Series(arr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "510fe5a3-9bf6-4d44-88d9-654ea81dc0fc",
+   "metadata": {},
+   "source": [
+    "### **[New Feature]** Negative dates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74776c25-6478-4d7e-85ea-8adad7a5e4df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arr3 = np.array([\"-999999-01-02\"], dtype=\"M8[s]\")\n",
+    "pd.Series(arr3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82846052-7568-45ee-8d64-c547e4524cae",
+   "metadata": {},
+   "source": [
+    "### By pandas 2.0.0, it will be possible to use negative dates directly in pandas:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd515a24-1b62-4ca4-9f2e-113e2661e74f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    pd.Series([\"-999999-01-02\"], dtype=\"datetime64[s]\")\n",
+    "except:\n",
+    "    print(\"Not yet!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "492dabbf-2667-4d65-9232-32bc0c329732",
+   "metadata": {},
+   "source": [
+    "### We can currently set a datum through `origin`\n",
+    "with limitations:\n",
+    "* Date must be numeric\n",
+    "* origin currently needs to be within the bounds,  1600-2300"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad41956b-a622-4fb4-a665-0e0291762643",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.to_datetime(13, unit='D')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a97b7a52-e536-4e84-86af-48a0c69ae95d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.to_datetime(13, unit='D', origin='1950-01-01')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba58ab95-d497-42b5-9cb0-3e15187cb3fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.to_datetime(-13, unit='D', origin='1950-01-01')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28cc9f4c-db6f-4e42-b30d-538c01f59ea8",
+   "metadata": {},
+   "source": [
+    "## Extension array\n",
+    "\n",
+    "* setting datum with dates stored as strings\n",
+    "* direction of time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7be245d9-b7b4-4b8e-b9bd-344177394f22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# dates need to be in thte index, do a groupby, then mean\n",
+    "# arr3.mean()\n",
+    "# arr3.set_index('')\n",
+    "\n",
+    "\n",
+    "# dates far into the future\n",
+    "arr2 = np.array([\"30456-01-02\"], dtype=\"M8[s]\")\n",
+    "\n",
+    "# as series\n",
+    "series = pd.Series(np.random.randint(0, 100, len(arr2)), index=pd.Index(arr2, name='date'), name='value')\n",
+    "\n",
+    "# series.groupby(series.index.date).mean()\n",
+    "series.groupby(series.index.year).mean()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "240ccd19-cf08-4ea6-b7e0-32d45acb85fd",
+   "metadata": {},
+   "source": [
+    "### **[New Feature]** Series analysis using Index with dates far into the future"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e7650a6-d9f9-4c01-a3ac-ce7daca30a5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# dates far into the future\n",
+    "arr2 = np.array([\"30456-01-02\"], dtype=\"M8[s]\")\n",
+    "\n",
+    "# as series\n",
+    "df = pd.DataFrame(np.random.randint(0, 100, len(arr2)), index=pd.Index(arr2, name='date'))\n",
+    "\n",
+    "# series.groupby(series.index.date).mean()\n",
+    "df.groupby(df.index.year).mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a350c19-cca7-4fb4-878c-9a3519539b24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# dates far into the future\n",
+    "start_year = 1300\n",
+    "stop_year = 13000\n",
+    "\n",
+    "arr = np.arange(np.datetime64(f\"{start_year}-01-01\"), np.datetime64(f\"{stop_year}-01-01\"), np.timedelta64(100, \"Y\"), dtype='datetime64[Y]').astype(\"M8[s]\")\n",
+    "series = pd.Series(np.random.randn(len(arr)), index=arr)\n",
+    "\n",
+    "series.groupby(series.index.year).mean()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/Non-nanosecond_Series.ipynb
+++ b/examples/Non-nanosecond_Series.ipynb
@@ -182,39 +182,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28cc9f4c-db6f-4e42-b30d-538c01f59ea8",
-   "metadata": {},
-   "source": [
-    "## Extension array\n",
-    "\n",
-    "* setting datum with dates stored as strings\n",
-    "* direction of time"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7be245d9-b7b4-4b8e-b9bd-344177394f22",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# dates need to be in thte index, do a groupby, then mean\n",
-    "# arr3.mean()\n",
-    "# arr3.set_index('')\n",
-    "\n",
-    "\n",
-    "# dates far into the future\n",
-    "arr2 = np.array([\"30456-01-02\"], dtype=\"M8[s]\")\n",
-    "\n",
-    "# as series\n",
-    "series = pd.Series(np.random.randint(0, 100, len(arr2)), index=pd.Index(arr2, name='date'), name='value')\n",
-    "\n",
-    "# series.groupby(series.index.date).mean()\n",
-    "series.groupby(series.index.year).mean()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "240ccd19-cf08-4ea6-b7e0-32d45acb85fd",
    "metadata": {},
    "source": [


### PR DESCRIPTION
This adds a notebook of the current capabilities around non-nanosecond timesteps in pandas. There are more integrations that are in progress (not yet merged). This notebook will need to be updated as new features are integrated. 